### PR TITLE
feat: :triangular_flag_on_post: Adds CLI Commands For help, version, debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+# Ignores All lock files
+*-lock.*
+*.lock

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,8 @@
 # Acode Language Server
- 
- Express websocket application for thw acode language servers plugin.
- 
- 
-## Running locally
 
+ Express websocket application for thw acode language servers plugin.
+
+## Running locally
 
 To setup and run this plugin locally:
 
@@ -13,9 +11,7 @@ To setup and run this plugin locally:
 - Run `npm install`
 - Start server (`node server.mjs`)
 
-
 ## Contributing
-
 
 Users can also add other language servers and send a pull request so they are
 added to the plugin.
@@ -27,4 +23,3 @@ You can also use the `python` mode as an example on how to setup a websocket
 proxy if the target language server can only be started as a websocket server.
 
 An example of a stdin and stdout language server would be added in future.
-

--- a/utils/handleArgvOptions.mjs
+++ b/utils/handleArgvOptions.mjs
@@ -1,0 +1,23 @@
+/**
+ *  @typedef {Object} CLICommand
+ *  @property {string} name Name for the command.
+ *  @property {Array<string>} aliases Aliases for the command.
+ *  @property {function} exec The function to execute.
+ */
+
+
+/**
+ * @param {string[]} argvArray `process.argv` Array parsed after slice(2) performed
+ * @param {CLICommand[]} commands 
+ */
+
+export function handleArgvOptions(argvArray, commands) {
+    argvArray.forEach((argv) => {
+
+        const command = commands.find((c) => c.name === argv || c.aliases.includes(argv));
+        if (!command) return console.log(`${argv.replace("--", "")}`);
+
+        command.exec()
+
+    })
+}


### PR DESCRIPTION
# ➕ Additions/Changes
Adds CLI commands (help, version, debug)
- Add .gitignore
- Create Utils folder for `handleArgvOptions`
- Removed extra spaces from Readme (Cause who likes your IDE/Code Editor to have yellow/red lines)

# ❓Why not use `yargs` ?
It's not being used currently, as there are not many complex CLI Commands. Plus, **Yargs** weighs about `292 kB` (source npmjs.com), which makes it a bit Extra compared to our usage.

For now, We can use our Implementation.

